### PR TITLE
Change ContentType from Set-NexusUserPasswrod and add -BodyAsSecureString on Invoke-Nexus

### DIFF
--- a/src/private/Invoke-Nexus.ps1
+++ b/src/private/Invoke-Nexus.ps1
@@ -19,6 +19,10 @@ function Invoke-Nexus {
 
         [Parameter()]
         [String]
+        $BodyAsSecureString,
+
+        [Parameter()]
+        [String]
         $File,
 
         [Parameter()]
@@ -42,14 +46,23 @@ function Invoke-Nexus {
 
         if($Body){
             $Params.Add('Body',$($Body | ConvertTo-Json -Depth 3))
-        } 
-        
+        }
+
         if($BodyAsArray){
             $Params.Add('Body',$($BodyAsArray | ConvertTo-Json -Depth 3))
         }
 
         if($BodyAsString){
             $Params.Add('Body',$BodyAsString)
+        }
+
+        if($BodyAsSecureString){
+            $Params.Add(
+                'Body',
+                [Runtime.InteropServices.Marshal]::PtrToStringBSTR(
+                    [Runtime.InteropServices.Marshal]::SecureStringToBSTR($BodyAsSecureString)
+                )
+            )
         }
 
         if($File){

--- a/src/public/Security/Users/Set-NexusUserPassword.ps1
+++ b/src/public/Security/Users/Set-NexusUserPassword.ps1
@@ -2,21 +2,21 @@ function Set-NexusUserPassword {
     <#
     .SYNOPSIS
     Change a user's password.
-    
+
     .DESCRIPTION
     Change a user's password.
-    
+
     .PARAMETER Username
     The userid the request should apply to
-    
+
     .PARAMETER NewPassword
     The new password to use.
-    
+
     .EXAMPLE
     Set-NexusUserPassword -Username jimmy -NewPassword ("Sausage2021" | ConvertTo-SecureString -AsPlainText -Force)
-    
+
     .NOTES
-    
+
     #>
     [CmdletBinding(HelpUri='https://steviecoaster.dev/NexuShell/Security/User/Set-NexusUserPassword/')]
     Param(
@@ -32,6 +32,6 @@ function Set-NexusUserPassword {
     process {
         $urislug = "/service/rest/v1/security/users/$Username/change-password"
 
-        Invoke-Nexus -Urislug $urislug -BodyAsString $NewPassword -Method PUT
+        Invoke-Nexus -Urislug $urislug -BodyAsSecureString $NewPassword -Method PUT -ContentType 'text/plain'
     }
 }


### PR DESCRIPTION
In relation to #9 this PR sets the content type to 'text/plain' when using `Set-NexusUserPasswrod`

Further, it adds a `BodyAsSecureString` parameter to `Invoke-Nexus` which converts the SecureString back to a String so that the API can read it.

This conversion uses `[Runtime.InteropServices.Marshal]` for Windows PowerShell compatibility (PowerShell 7 can do `ConvertFrom-SecureString -AsPlainText` but 🤷‍♂️)

I checked (quickly) that there are no other functions that should be using `BodyAsSecureString` at this time.

_Also, sorry... some formatting changes snuck into my commit. Yell at me to remove them if you'd like 😅_