### PR TITLE
(#8) Populate user object correctly

### DIFF
--- a/src/public/Security/Users/Set-NexusUser.ps1
+++ b/src/public/Security/Users/Set-NexusUser.ps1
@@ -92,7 +92,7 @@ function Set-NexusUser {
             throw "Username cannot be changed or not found in list of existing users"
         }
 
-        switch($false){
+        switch($null){
             $FirstName { $FirstName = $user.FirstName}
             $LastName { $LastName = $user.LastName }
             $EmailAddress { $EmailAddress = $user.EmailAddress }
@@ -102,13 +102,14 @@ function Set-NexusUser {
         }
 
         $Body = @{
-            userName = $Username
+            userId = $Username
             firstName = $FirstName
             lastName = $LastName
             emailAddress = $EmailAddress
             status = $Status.ToLower()
-            readOnly = $ReadOnly
+            readOnly = [bool]$ReadOnly
             roles = $Roles
+            source = $($user.Source)
         }
 
         Write-Verbose ($Body | ConvertTo-Json)


### PR DESCRIPTION
When updating an existing Nexus user, we should only touch properties which have been passed as parameters, and reuse existing user property values. This commit addresses a bug where existing properties were not hydrated onto the body of the request to update a user.
Tested against Nexus OSS 3.31.1-01 to be working as expected

Fixes #8 