### PR TITLE
(#7) Allow Get-NexusApiKey to work against a different user

### DIFF
--- a/src/private/Get-NexusUserToken.ps1
+++ b/src/private/Get-NexusUserToken.ps1
@@ -26,6 +26,11 @@ function Get-NexusUserToken {
 
         $uri = $UriBase + $slug
 
+        $credPair = "{0}:{1}" -f $Credential.UserName,$Credential.GetNetworkCredential().Password
+        $encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($credPair))
+        $ApiKeyHeader = @{ Authorization = "Basic $encodedCreds"}
+
+
         $data = @{
             action = 'rapture_Security'
             method = 'authenticationToken'
@@ -35,7 +40,7 @@ function Get-NexusUserToken {
         }
 
         Write-Verbose ($data | ConvertTo-Json)
-        $result = Invoke-RestMethod -Uri $uri -Method POST -Body ($data | ConvertTo-Json) -ContentType 'application/json' -Headers $header -UseBasicParsing
+        $result = Invoke-RestMethod -Uri $uri -Headers $ApiKeyHeader -Method POST -Body ($data | ConvertTo-Json) -ContentType 'application/json' -UseBasicParsing
         $token = $result.result.data
         $token
     }

--- a/src/public/Security/APIKey/Get-NexusNuGetApiKey.ps1
+++ b/src/public/Security/APIKey/Get-NexusNuGetApiKey.ps1
@@ -31,7 +31,12 @@ function Get-NexusNuGetApiKey {
 
         $uri = $UriBase + $slug
 
-        Invoke-RestMethod -Uri $uri -Method GET -ContentType 'application/json' -Headers $header -UseBasicParsing
+
+        $credPair = "{0}:{1}" -f $Credential.UserName,$Credential.GetNetworkCredential().Password
+        $encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($credPair))
+        $ApiKeyHeader = @{ Authorization = "Basic $encodedCreds"}
+
+        Invoke-RestMethod -Uri $uri -Headers $ApiKeyHeader -Method GET -ContentType 'application/json' -UseBasicParsing
 
     }
 }


### PR DESCRIPTION
Currently the function reuses the initial header for Connect-NexusServer, which is a different base64 encoded credential
than the one being passed. This commit builds a new header from the supplied required Credential parameter of the
user which you wish to retrieve the key for.
Tested against Nexus OSS 3.31.1-01

Fixes #7 