### PR TITLE
(#30) Adds Remove-NexusComponent

### DIFF
--- a/src/public/Components/Get-NexusComponent.ps1
+++ b/src/public/Components/Get-NexusComponent.ps1
@@ -1,24 +1,22 @@
 function Get-NexusComponent {
     <#
     .SYNOPSIS
-    Retrieve asset information from Nexus
+    Retrieve component information from Nexus
     
     .DESCRIPTION
-    Retrieve asset informatino from Nexus
+    Retrieve component information from Nexus
     
     .PARAMETER RepositoryName
     The repository to query for components
     
     .PARAMETER Id
-    A specific asset to retrieve
+    A specific component to retrieve
     
     .EXAMPLE
-    Get-NexusAsset -RepositoryName Dev
+    Get-NexusComponent -RepositoryName Dev
 
     .EXAMPLE
-    Get-NexusAsset -Id RGV2OmM2MGJjNmI5NjEyZjQ3ZDM5ZTc2ZmMwNTI1ODg0M2Rj
-    
-    .NOTES
+    Get-NexusComponent -Id RGV2OmM2MGJjNmI5NjEyZjQ3ZDM5ZTc2ZmMwNTI1ODg0M2Rj
     #>
     [CmdletBinding(HelpUri = 'https://steviecoaster.dev/NexuShell/Components/Get-NexusComponent/', DefaultParameterSetName = "repo")]
     Param(

--- a/src/public/Components/Remove-NexusComponent.ps1
+++ b/src/public/Components/Remove-NexusComponent.ps1
@@ -1,0 +1,33 @@
+function Remove-NexusComponent {
+    <#
+    .SYNOPSIS
+    Removes a component from a Nexus Repository
+
+    .DESCRIPTION
+    Removes a component from a Nexus Repository
+
+    .PARAMETER Id
+    The ID of the component to remove
+
+    .EXAMPLE
+    Remove-NexusComponent -Id RGV2OmM2MGJjNmI5NjEyZjQ3ZDM5ZTc2ZmMwNTI1ODg0M2Rj
+
+    .EXAMPLE
+    Get-NexusComponent -Repository dev | Where-Object {$_.Name -eq "somePackage" -and $_.Version "1.2.3"} | Remove-NexusComponent -Confirm:$false
+    #>
+    [CmdletBinding(HelpUri='https://steviecoaster.dev/NexuShell/Assets/Remove-NexusComponent/', SupportsShouldProcess, ConfirmImpact='High')]
+    Param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [String[]]
+        $Id
+    )
+    process {
+        $Id | ForEach-Object {
+            $urislug = "/service/rest/v1/components/$($_)"
+
+            if ($PSCmdlet.ShouldProcess("$($_)", "Remove Component")) {
+                $null = Invoke-Nexus -UriSlug $urislug -Method DELETE
+            }
+        }
+    }
+}

--- a/src/public/Repository/Remove-NexusRepository.ps1
+++ b/src/public/Repository/Remove-NexusRepository.ps1
@@ -23,7 +23,7 @@ function Remove-NexusRepository {
         [Parameter(Mandatory,ValueFromPipeline,ValueFromPipelineByPropertyName)]
         [Alias('Name')]
         [ArgumentCompleter( {
-                param($command, $WordToComplete, $CommandAst, $FakeBoundParams)
+                param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
                 $repositories = (Get-NexusRepository).Name
 
                 if ($WordToComplete) {

--- a/tests/public/Components/Remove-NexusComponent.Tests.ps1
+++ b/tests/public/Components/Remove-NexusComponent.Tests.ps1
@@ -1,0 +1,139 @@
+#requires -Modules NexuShell
+
+Describe "Remove-NexusComponent" {
+    BeforeAll {
+        $InModule = @{
+            ModuleName = "NexuShell"
+        }
+
+        InModuleScope @InModule {
+            $script:header = @{
+                Authentication = "fake auth"
+            }
+        }
+
+        Mock Invoke-Nexus @InModule
+    }
+
+    Context "Removing a component from Nexus" {
+        BeforeAll {
+            $TestId = (New-Guid).Guid
+            $Result = Remove-NexusComponent -Id $TestId -Confirm:$false
+        }
+
+        It "Attempts to remove the correct component" {
+            Assert-MockCalled Invoke-Nexus @InModule -ParameterFilter {
+                $UriSlug -eq "/service/rest/v1/components/$TestId" -and
+                $Method -eq "Delete"
+            } -Scope Context
+        }
+
+        It "Returns nothing" {
+            $Result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Removing multiple components from Nexus" {
+        BeforeAll {
+            $TestIds = (New-Guid).Guid, (New-Guid).Guid
+
+            Mock Get-NexusComponent {
+                [PSCustomObject]@{
+                    Id         = $TestIds[0]
+                    Repository = "dev"
+                    Format     = "nuget"
+                    Group      = $null
+                    Name       = "somepackage"
+                    Version    = "1.0"
+                    Assets     = @{}
+                }
+                [PSCustomObject]@{
+                    Id         = $TestIds[1]
+                    Repository = "dev"
+                    Format     = "nuget"
+                    Group      = $null
+                    Name       = "somepackage"
+                    Version    = "1.1"
+                    Assets     = @{}
+                }
+            }
+
+            $Result = Remove-NexusComponent -Id $TestIds -Confirm:$false
+        }
+
+        It "Attempts to remove the correct components" {
+            Assert-MockCalled Invoke-Nexus @InModule -ParameterFilter {
+                $UriSlug -eq "/service/rest/v1/components/$($TestIds[0])" -and
+                $Method -eq "Delete"
+            } -Scope Context -Times 1
+
+            Assert-MockCalled Invoke-Nexus @InModule -ParameterFilter {
+                $UriSlug -eq "/service/rest/v1/components/$($TestIds[1])" -and
+                $Method -eq "Delete"
+            } -Scope Context -Times 1
+        }
+
+        It "Returns nothing" {
+            $Result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Removing components from pipelined input" {
+        BeforeAll {
+            $TestIds = (New-Guid).Guid, (New-Guid).Guid
+
+            Mock Get-NexusComponent {
+                [PSCustomObject]@{
+                    Id         = $TestIds[0]
+                    Repository = "dev"
+                    Format     = "nuget"
+                    Group      = $null
+                    Name       = "somepackage"
+                    Version    = "1.0"
+                    Assets     = @{}
+                }
+                [PSCustomObject]@{
+                    Id         = $TestIds[1]
+                    Repository = "dev"
+                    Format     = "nuget"
+                    Group      = $null
+                    Name       = "somepackage"
+                    Version    = "1.1"
+                    Assets     = @{}
+                }
+            }
+
+            $Result = Get-NexusComponent -Repository dev | Remove-NexusComponent -Confirm:$false
+        }
+
+        It "Attempts to remove both components" {
+            Assert-MockCalled Invoke-Nexus @InModule -ParameterFilter {
+                $UriSlug -eq "/service/rest/v1/components/$($TestIds[0])" -and
+                $Method -eq "Delete"
+            } -Scope Context -Times 1
+
+            Assert-MockCalled Invoke-Nexus @InModule -ParameterFilter {
+                $UriSlug -eq "/service/rest/v1/components/$($TestIds[1])" -and
+                $Method -eq "Delete"
+            } -Scope Context -Times 1
+        }
+
+        It "Returns nothing" {
+            $Result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "ShouldProcess Compatibility" {
+        BeforeAll {
+            $TestId = (New-Guid).Guid
+            Remove-NexusComponent -Id $TestId -WhatIf
+        }
+
+        It "Does not attempt to remove the component when called with -WhatIf" {
+            Assert-MockCalled Invoke-Nexus @InModule -ParameterFilter {
+                $UriSlug -eq "/service/rest/v1/components/$TestId" -and
+                $Method -eq "Delete"
+            } -Scope Context -Times 0
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes a few small issues, and adds a Remove-NexusComponent function.

## Reason
When attempting to automate cleanup of some packages, I found this to be missing from the module. It seemed useful, and quick to add, so I did so.

I also had a few files unstaged that I'd probably meant to push previously, so added them in.

## Testing
- This has been tested in PowerShell 7.3.2 and 5.1
- It has been tested against a nuget repository on a Nexus instance running 3.45.1-01
- It has been tested with standard parameter input, and pipelining