### PR TITLE
(enhance) Adds LocalService Option to Connect-NexusServer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,27 +19,29 @@ jobs:
       ChocoApiKey: ${{ secrets.ChocoApiKey }}
 
     steps:
-      - uses: actions/checkout@v2
-        
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for GitVersion to behave
+
       - name: GitVersion
         id: gitversion
-        uses: PoshCode/Actions/gitversion@v1
+        uses: PoshCode/Actions/gitversion@v1.0.1
 
       - name: Install-RequiredModules
         uses: PoshCode/Actions/install-requiredmodules@v1
 
       - name: Build Module
-        run: .\build.ps1 -Build -SemVer "${{ steps.gitversion.outputs.LegacySemVerPadded }}"
+        run: .\build.ps1 -Build -SemVer "${{ steps.gitversion.outputs.SemVer }}"
         shell: pwsh
 
       - name: Upload Built Module
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: NexuShell.${{ steps.gitversion.outputs.LegacySemVerPadded }}
+          name: NexuShell.${{ steps.gitversion.outputs.SemVer }}
           path: .\Output
 
       - name: Test Module
-        run: .\build.ps1 -TestPrePublish -SemVer "${{ steps.gitversion.outputs.LegacySemVerPadded }}"
+        run: .\build.ps1 -TestPrePublish -SemVer "${{ steps.gitversion.outputs.SemVer }}"
         shell: pwsh
 
       - name: Upload Test Results
@@ -66,4 +68,4 @@ jobs:
 
       - name: Publish Module
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: .\build.ps1 -DeployToGallery -SemVer "${{ steps.gitversion.outputs.LegacySemVerPadded }}"
+        run: .\build.ps1 -DeployToGallery -SemVer "${{ steps.gitversion.outputs.SemVer }}"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build Module",
+            "type": "shell",
+            "command": "${workspaceFolder}\\Build.ps1 -Build",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/Build.psd1
+++ b/Build.psd1
@@ -1,4 +1,5 @@
 @{
     ModuleManifest = ".\src\NexuShell.psd1"
     SourceDirectories = "private", "public"
+    Suffix = "Suffix.ps1"
 }

--- a/build.ps1
+++ b/build.ps1
@@ -24,7 +24,11 @@ param(
     [string]
     $SemVer = $(
         if (Get-Command gitversion -ErrorAction SilentlyContinue) {
-            (gitversion | ConvertFrom-Json).LegacySemVerPadded
+            if (([version]((gitversion /version).Split('+')[0])).Major -gt 5) {
+                gitversion /showvariable SemVer
+            } else {
+                gitversion /showvariable LegacySemVerPadded
+            }
         }
     )
 )

--- a/build.ps1
+++ b/build.ps1
@@ -96,13 +96,15 @@ process {
             Compress-Archive -Path $root\Output\* -DestinationPath $PackageSource\tools\NexuShell.zip -Force #Added force to allow local testing without shenanigans
 
             if (Test-Path "$PackageSource\tools\NexuShell.zip") {
-                choco pack $Nuspec.FullName --output-directory $root
+                choco pack $Nuspec.FullName --version $SemVer --output-directory $root
             } else {
                 throw "Welp, ya need the zip in the tools folder, dumby"
             }
 
-            Get-ChildItem $PackageSource -recurse -filter *.nupkg | ForEach-Object { 
-                choco push $_.FullName -s https://push.chocolatey.org --api-key="'$($env:ChocoApiKey)'"
+            if ($env:ChocoApiKey) {
+                Get-ChildItem $PackageSource -Recurse -Filter *.nupkg | ForEach-Object { 
+                    choco push $_.FullName -s https://push.chocolatey.org --api-key="'$($env:ChocoApiKey)'"
+                }
             }
         }
     }

--- a/src/NexuShell.psd1
+++ b/src/NexuShell.psd1
@@ -23,7 +23,7 @@
     FunctionsToExport = @()
     CmdletsToExport   = @()
     VariablesToExport = @()
-    AliasesToExport   = @('Get-NexusLifecycle','New-NexusLifecycle')
+    AliasesToExport   = @('Get-NexusLifecycle','New-NexusLifecycle','Get-NexusUri')
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData = @{

--- a/src/Suffix.ps1
+++ b/src/Suffix.ps1
@@ -1,0 +1,1 @@
+$script:InstalledNexusService = Get-NexusRepositoryServiceInstall -ErrorAction SilentlyContinue

--- a/src/nuget/tools/chocolateyInstall.ps1
+++ b/src/nuget/tools/chocolateyInstall.ps1
@@ -25,7 +25,11 @@ $PathSegment = @{
     Core    = "PowerShell\Modules\"
 
     AllUsers = $env:ProgramFiles
-    CurrentUser = $PROFILE | Split-Path | Split-Path
+    CurrentUser = try {
+        $PROFILE | Split-Path | Split-Path
+    } catch {
+        Write-Warning "Profile is set to '$($PROFILE)'. Current user '$($env:USERNAME)' may not be able to install at user level."
+    }
 }
 
 $Parameters = Get-PackageParameters

--- a/src/private/Get-NexusCertificateDomain.ps1
+++ b/src/private/Get-NexusCertificateDomain.ps1
@@ -1,0 +1,40 @@
+function Get-NexusCertificateDomain {
+    <#
+    .SYNOPSIS
+    Returns the Certificate domain for the specified Nexus configuration, if present.
+
+    .DESCRIPTION
+    Uses the KeyTool to open the currently used KeyStore and grab the domain.
+
+    .PARAMETER DataDir
+    The path to the Sonatype Nexus data directory, e.g. C:\ProgramData\sonatype-work\nexus3.
+
+    .PARAMETER ProgramDir
+    The path to the Sonatype Nexus program files, e.g. C:\ProgramData\nexus.
+
+    .EXAMPLE
+    Get-NexusCertificateDomain -DataDir C:\ProgramData\sonatype-work\nexus3 -ProgramDir C:\ProgramData\nexus
+    #>
+    param(
+        [string]$DataDir = $script:InstalledNexusService.DataFolder,
+  
+        [string]$ProgramDir = $script:InstalledNexusService.ProgramFolder
+    )
+    $Config = Get-NexusConfiguration -Path $DataDir\etc\nexus.properties
+    if ($Config.'nexus-args'.Split(',') -contains '${jetty.etc}/jetty-https.xml') {
+        [xml]$HttpsConfig = Get-Content $ProgramDir\etc\jetty\jetty-https.xml
+        $KeyToolPath = Join-Path $ProgramDir "jre/bin/keytool.exe"
+        $KeyStorePath = Join-Path (Join-Path $ProgramDir "etc/ssl") $HttpsConfig.SelectSingleNode("//Set[@name='KeyStorePath']").'#text'
+        $KeyStorePassword = $HttpsConfig.SelectSingleNode("//Set[@name='KeyStorePassword']").'#text'
+  
+        if ((Test-Path $KeyToolPath) -and (Test-Path $KeyStorePath)) {
+            # Running in a job, as otherwise KeyTool fails when run without input
+            Start-Job {
+                $KeyToolOutput = $using:KeyStorePassword | & "$using:KeyToolPath" -list -v -keystore "$using:KeyStorePath" -J"-Duser.language=en" 2>$null
+                if ($KeyToolOutput -join "`n" -match "(?smi)Certificate\[1\]:\nOwner: CN=(?<Domain>.+?)(\n|,)") {
+                    $Matches.Domain
+                }
+            } | Receive-Job -Wait
+        }
+    }
+}

--- a/src/private/Get-NexusConfiguration.ps1
+++ b/src/private/Get-NexusConfiguration.ps1
@@ -1,0 +1,27 @@
+function Get-NexusConfiguration {
+    <#
+    .SYNOPSIS
+    Returns a list of settings configured in nexus.properties.
+
+    .DESCRIPTION
+    Retrieves the specified file (defaulting to the default install location) and returns each active setting.
+
+    .PARAMETER Path
+    The path to the properties file to return.
+
+    .EXAMPLE
+    Get-NexusConfiguration
+    # Returns all properties and values
+
+    .EXAMPLE
+    (Get-NexusConfiguration).'application-port-ssl'
+    # Returns the value for a single property, 'application-port-ssl'
+    #>
+    [CmdletBinding()]
+    param(
+        $Path = (Join-Path $script:InstalledNexusService.DataFolder "etc\nexus.properties")
+    )
+    Get-Content $Path | Where-Object {
+        $_ -and $_ -notmatch "^\W*#"
+    } | ConvertFrom-StringData
+}

--- a/src/private/Get-NexusRepositoryServiceInstall.ps1
+++ b/src/private/Get-NexusRepositoryServiceInstall.ps1
@@ -1,0 +1,41 @@
+function Get-NexusRepositoryServiceInstall {
+    <#
+    .SYNOPSIS
+    If found, returns the name of the Nexus service and the install and data directories it uses.
+
+    .DESCRIPTION
+    Checks all current services for services that run "nexus.exe", then returns the program and data directories for one/each.
+
+    .PARAMETER AllResults
+    To speed up execution, by default we check services until we find the first one running nexus.exe.
+    If you have more than one instance installed, you can use this switch to check all services.
+
+    .EXAMPLE
+    Get-NexusRepositoryInstallValues
+    #>
+    [CmdletBinding()]
+    param(
+        # By default, we assume there is only one service. This searches for all installed services.
+        [switch]$AllResults
+    )
+    # If you have a lot of services, searching them all may take longer -
+    # so we can stop searching when we find the first service matching nexus.exe.
+    $ResultCount = @{}
+    if (-not $AllResults) { $ResultCount.First = 1 }
+  
+    $NexusService = Get-ChildItem HKLM:\System\CurrentControlSet\Services\ | Where-Object {
+      ($ImagePath = Get-ItemProperty -Path $_.PSPath -Name ImagePath -ErrorAction SilentlyContinue) -and
+        $ImagePath.ImagePath.Trim('"''').EndsWith('\nexus.exe')
+    } | Select-Object @ResultCount
+  
+    foreach ($Service in $NexusService) {
+        $ServiceName = $Service.PSChildName
+        $TargetFolder = (Get-ItemProperty -Path $Service.PSPath).ImagePath.Trim('"''') | Split-Path | Split-Path
+        $DataFolder = Convert-Path (Join-Path $TargetFolder "$((Get-Content $TargetFolder\bin\nexus.vmoptions) -match '^-Dkaraf.data=(?<RelativePath>.+)$' -replace '^-Dkaraf.data=')")
+        [PSCustomObject]@{
+            ServiceName   = $ServiceName
+            ProgramFolder = $TargetFolder
+            DataFolder    = $DataFolder
+        }
+    }
+}

--- a/src/private/Invoke-Nexus.ps1
+++ b/src/private/Invoke-Nexus.ps1
@@ -31,11 +31,21 @@ function Invoke-Nexus {
 
         [Parameter(Mandatory)]
         [String]
-        $Method
+        $Method,
+
+        [Parameter()]
+        [hashtable]
+        $Headers
     )
     process {
         $UriBase = "$($protocol)://$($Hostname):$($port)$($ContextPath)"
         $Uri = $UriBase + $UriSlug
+        if ($Headers) {
+            $local:header = $script:header.Clone()
+            $Headers.Keys.ForEach{
+                $header[$_] = $Headers[$_]
+            }
+        }
         $Params = @{
             Headers = $header
             ContentType = $ContentType

--- a/src/private/Invoke-Nexus.ps1
+++ b/src/private/Invoke-Nexus.ps1
@@ -80,6 +80,19 @@ function Invoke-Nexus {
             $Params.Add('InFile',$File)
         }
 
-        Invoke-RestMethod @Params
+        try {
+            Invoke-RestMethod @Params -ErrorAction Stop
+        } catch {
+            try {
+                $JsonMessage = $_.ErrorDetails.Message | ConvertFrom-Json -ErrorAction Stop
+            } catch {<# Not a Json message #>}
+            if ($JsonMessage) {
+                # If there's a message from the server, display it appropriately
+                Write-Error -Message $Message -Exception $_.Exception
+            } else {
+                # Otherwise, rethrow
+                throw
+            }
+        }
     }
 }

--- a/src/public/Asset/Get-NexusAsset.ps1
+++ b/src/public/Asset/Get-NexusAsset.ps1
@@ -45,8 +45,7 @@ function Get-NexusAsset {
 
             $result.items
 
-            if ($($result.continuationToken)) {
-
+            while ($($result.continuationToken)) {
                 $urislug = "/service/rest/v1/assets?continuationToken=$($result.continuationToken)&repository=$($RepositoryName)"
                 $result = Invoke-Nexus -Urislug $urislug -Method GET
                 $result.items

--- a/src/public/Asset/Remove-NexusRepositoryFolder.ps1
+++ b/src/public/Asset/Remove-NexusRepositoryFolder.ps1
@@ -1,0 +1,53 @@
+function Remove-NexusRepositoryFolder {
+    <#
+    .SYNOPSIS
+    Removes a given folder from a repository from the Nexus instance
+
+    .PARAMETER RepositoryName
+    The repository to remove from
+
+    .PARAMETER Name
+    The name of the folder to remove
+
+    .EXAMPLE
+    Remove-NexusRepositoryFolder -RepositoryName MyNuGetRepo -Name 'v3'
+    # Removes the v3 folder in the MyNuGetRepo repository
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RepositoryName,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+    end {
+        if (-not $header) {
+            throw "Not connected to Nexus server! Run Connect-NexusServer first."
+        }
+
+        $ApiParameters = @{
+            UriSlug = "/service/extdirect"
+            Method  = "POST"
+            Body    = @{
+                action = "coreui_Component"
+                method =  "deleteFolder"
+                data   = @(
+                    $Name,
+                    $RepositoryName
+                )
+                type   = "rpc"
+                tid    = Get-Random -Minimum 1 -Maximum 100
+            }
+            Headers = @{
+                "X-Nexus-UI" = "true"
+            }
+        }
+
+        $Result = Invoke-Nexus @ApiParameters
+
+        if (-not $Result.result.success) {
+            throw "Failed to delete folder: $($Result.result.message)"
+        }
+    }
+}

--- a/src/public/Component/New-NexusNugetComponent.ps1
+++ b/src/public/Component/New-NexusNugetComponent.ps1
@@ -2,21 +2,21 @@ function New-NexusNugetComponent {
     <#
     .SYNOPSIS
     Uploads a NuGet package to Nexus through the Components API
-    
+
     .DESCRIPTION
     Uploads a NuGet package to Nexus through the Components API
-    
+
     .PARAMETER RepositoryName
-    The repository to upload too
-    
+    The repository to upload to
+
     .PARAMETER NuGetComponent
     The NuGet package to upload
     
     .EXAMPLE
     New-NexusNugetComponent -RepositoryName ProdNuGet -NuGetComponent C:\temp\awesomepackage.0.1.0.nupkg
-    
-    .NOTES
-    
+
+    .EXAMPLE
+    Get-ChildItem ~\Downloads\ -Filter *.nupkg | New-NexusNugetComponent -RepositoryName ChocolateyTest
     #>
     [CmdletBinding()]
     Param(
@@ -24,45 +24,45 @@ function New-NexusNugetComponent {
         [String]
         $RepositoryName,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias("PSPath")]
         [ValidateScript( {
                 Test-Path $_
             })]
         [String]
         $NuGetComponent
     )
-
-    process {
-
-        $urislug = "/service/rest/v1/components?repository=$($RepositoryName)"
-        $UriBase = "$($protocol)://$($Hostname):$($port)$($ContextPath)"
-        $Uri = $UriBase + $UriSlug
-
-        $boundary = [System.Guid]::NewGuid().ToString(); 
-        $ContentType = 'application/octet-stream'
-        $FileStream = [System.IO.FileStream]::new($NuGetComponent, [System.IO.FileMode]::Open)
-        $FileHeader = [System.Net.Http.Headers.ContentDispositionHeaderValue]::new('form-data')
-        $FileHeader.Name = 'nuget.asset'
-        $FileHeader.FileName = Split-Path -leaf $NuGetComponent
-        $FileContent = [System.Net.Http.StreamContent]::new($FileStream)
-        $FileContent.Headers.ContentDisposition = $FileHeader
-        $FileContent.Headers.ContentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::Parse($ContentType)
-
-        $MultipartContent = [System.Net.Http.MultipartFormDataContent]::new()
-        $MultipartContent.Add($FileContent)
-
-        $params = @{
-            Uri         = $Uri
-            Method      = 'POST'
-            ContentType = "multipart/form-data; boundary=----WebKitFormBoundary$($Boundary)"
-            Body        = $MultipartContent
-            Headers     = $header
-            UseBasicParsing = $true
+    begin {
+        if (-not ('System.Net.Http.HttpClient' -as [type])) {
+            Add-Type -AssemblyName 'System.Net.Http'
         }
 
-        $null = Invoke-WebRequest @params
-        
-    }
-    
+        $Uri = "$($protocol)://$($Hostname):$($port)$($ContextPath.TrimEnd('/'))/service/rest/v1/components?repository=$($RepositoryName)"
 
+        $Client = [System.Net.Http.HttpClient]::new()
+        $Client.DefaultRequestHeaders.Authorization = $header.Authorization
+    }
+    process {
+        try {
+            $Content = [System.Net.Http.MultipartFormDataContent]::new()
+            $FileName = [System.IO.Path]::GetFileName($NuGetComponent)
+            $FileStream = [System.IO.File]::OpenRead((Convert-Path $NuGetComponent))
+            $FileContent = [System.Net.Http.StreamContent]::new($FileStream)
+            $Content.Add($FileContent, 'nuget.asset', $FileName)
+
+            $Result = $Client.PostAsync($Uri, $Content).Result
+            if ($Result.EnsureSuccessStatusCode()) {
+                Write-Verbose "'$($FileName)' was successfully uploaded to '$($RepositoryName)'"
+            }
+        } catch {
+            Write-Error "'$($FileName)' failed to upload to '$($RepositoryName)': $($Result.ReasonPhrase)`n$_"
+        } finally {
+            if ($Content) {$Content.Dispose()}
+            if ($FileStream) {$FileStream.Dispose()}
+            if ($FileContent) {$FileContent.Dispose()}
+        }
+    }
+    end {
+        if ($Client) {$Client.Dispose()}
+    }
 }

--- a/src/public/Connect-NexusServer.ps1
+++ b/src/public/Connect-NexusServer.ps1
@@ -20,7 +20,16 @@ function Connect-NexusServer {
     
     .PARAMETER Sslport
     If not the default 8443 provide the current SSL port your Nexus server uses
-    
+
+    .PARAMETER LocalService
+    Connects to a locally running instance of Nexus, if it can be found
+
+    .EXAMPLE
+    Connect-NexusServer -LocalService -Credential admin
+
+    .EXAMPLE
+    Connect-NexusServer -LocalService -Credential admin -Hostname nexus.fabrikam.com
+
     .EXAMPLE
     Connect-NexusServer -Hostname nexus.fabrikam.com -Credential (Get-Credential)
 
@@ -30,66 +39,83 @@ function Connect-NexusServer {
     .EXAMPLE
     Connect-NexusServer -Hostname nexus.fabrikam.com -Credential $Cred -UseSSL -Sslport 443
     #>
-    [cmdletBinding(HelpUri='https://nexushell.dev/Connect-NexusServer/')]
+    [CmdletBinding(DefaultParameterSetName="Specified", HelpUri='https://nexushell.dev/Connect-NexusServer/')]
     param(
-        [Parameter(Mandatory,Position=0)]
+        [Parameter(ParameterSetName="Specified", Mandatory, Position=0)]
+        [Parameter(ParameterSetName="LocalService", Position=0)]
         [Alias('Server')]
         [String]
         $Hostname,
 
-        [Parameter(Mandatory,Position=1)]
+        [Parameter(Mandatory, Position=1)]
         [System.Management.Automation.PSCredential]
         $Credential,
 
-        [Parameter()]
+        [Parameter(ParameterSetName="Specified")]
         [String]
         $Path = "/",
 
-        [Parameter()]
+        [Parameter(ParameterSetName="Specified")]
         [Switch]
         $UseSSL,
 
-        [Parameter()]
+        [Parameter(ParameterSetName="Specified")]
         [String]
-        $Sslport = '8443'
+        $Sslport = '8443',
+
+        [Parameter(ParameterSetName="LocalService", Mandatory)]
+        [Switch]
+        $LocalService
     )
-
-    process {
-
-        if($UseSSL){
-            $script:protocol = 'https'
-            $script:port = $Sslport
-        } else {
-            $script:protocol = 'http'
-            $script:port = '8081'
-        }
-
-        $script:HostName = $Hostname
-        $script:ContextPath = $Path.TrimEnd('/')
-
+    end {
         $credPair = "{0}:{1}" -f $Credential.UserName,$Credential.GetNetworkCredential().Password
 
         $encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($credPair))
 
-        $script:header = @{ Authorization = "Basic $encodedCreds"}
+        $script:header = @{ Authorization = "Basic $encodedCreds" }
         $script:Credential = $Credential
 
-        try {
-            $url = "$($protocol)://$($Hostname):$($port)$($ContextPath)/service/rest/v1/status"
+        switch ($PSCmdlet.ParameterSetName) {
+            "Specified" {
+                if($UseSSL){
+                    $script:protocol = 'https'
+                    $script:port = $Sslport
+                } else {
+                    $script:protocol = 'http'
+                    $script:port = '8081'
+                }
 
-            $params = @{
-                Headers = $header
-                ContentType = 'application/json'
-                Method = 'GET'
-                Uri = $url
-                UseBasicParsing = $true
+                $script:HostName = $Hostname
+                $script:ContextPath = $Path.TrimEnd('/')
+
+                $uri = "$($protocol)://$($Hostname):$($port)$($ContextPath)"
             }
+            "LocalService" {
+                $UriArgs = @{}
+                if ($Hostname) {
+                    $UriArgs.HostnameOverride = $Hostname
+                }
+                [uri]$uri = Get-NexusUri @UriArgs
 
-            $result = Invoke-RestMethod @params -ErrorAction Stop
-            Write-Host "Connected to $Hostname" -ForegroundColor Green
+                $script:protocol = $uri.Scheme
+                $script:port = $uri.Port
+                $script:HostName = $uri.Host
+                $script:ContextPath = $uri.LocalPath.TrimEnd('/')
+            }
         }
 
-        catch {
+        $params = @{
+            Headers = $header
+            ContentType = 'application/json'
+            Method = 'GET'
+            Uri = "$($uri.ToString().TrimEnd('/'))/service/rest/v1/status"
+            UseBasicParsing = $true
+        }
+
+        try {
+            $null = Invoke-RestMethod @params -ErrorAction Stop
+            Write-Host "Connected to $($script:HostName)" -ForegroundColor Green
+        } catch {
             $_.Exception.Message
         }
     }

--- a/src/public/Get-NexusLocalServiceUri.ps1
+++ b/src/public/Get-NexusLocalServiceUri.ps1
@@ -1,0 +1,92 @@
+function Get-NexusLocalServiceUri {
+    <#
+    .SYNOPSIS
+    Returns the base URI used to access Sonatype Nexus (and it's API)
+
+    .DESCRIPTION
+    Checks configuration files in order to find which schema, FQDN, port, and path Nexus is being run on, so that we can connect to it.
+
+    .PARAMETER DataDir
+    The path to the Sonatype Nexus data directory, e.g. C:\ProgramData\sonatype-work\nexus3.
+
+    .PARAMETER ProgramDir
+    The path to the Sonatype Nexus program files, e.g. C:\ProgramData\nexus.
+
+    .PARAMETER ConfigPath
+    The path to the in-use config file. Checks for the existance of nexus.properties, and falls back to nexus-default.properties if not present.
+
+    .PARAMETER HostnameOverride
+    If a wildcard certificate is used, or you want to specify a particular FQDN to access Nexus, you can override the attempted lookup with this parameter.
+
+    .EXAMPLE
+    Get-NexusLocalServiceUri
+
+    .EXAMPLE
+    Get-NexusLocalServiceUri -HostnameOverride nexus.fabrikam.com
+    #>
+    [CmdletBinding()]
+    [Alias("Get-NexusUri")]
+    param(
+        [Parameter()]
+        [string]$DataDir = $script:InstalledNexusService.DataFolder,
+  
+        [Parameter()]
+        [string]$ProgramDir = $script:InstalledNexusService.ProgramFolder,
+  
+        [Parameter()]
+        [string]$ConfigPath = $(
+            if (Test-Path $DataDir/etc/nexus.properties) {
+                "$DataDir/etc/nexus.properties"
+            } elseif (Test-Path $ProgramDir/etc/nexus-default.properties) {
+                "$ProgramDir/etc/nexus-default.properties"
+            }
+        ),
+
+        [string]$HostnameOverride
+    )
+    $Scheme, $Hostname, $Port, $Path = if (Test-Path $ConfigPath) {
+        $Config = Get-NexusConfiguration -Path $ConfigPath -ErrorAction SilentlyContinue
+  
+        if ($Config.'application-port-ssl' -gt 0) {
+            'https'
+            if ($CertDomain = Get-NexusCertificateDomain -ConfigPath $ConfigPath) {
+                if (-not $script:OverriddenDomains) { $script:OverriddenDomains = @{} }
+                if ($CertDomain -notmatch '^\*') {
+                    $CertDomain
+                } elseif ($CertDomain -match '^\*' -and $HostnameOverride -like $CertDomain) {
+                    ($script:OverriddenDomains[$CertDomain] = $HostnameOverride)
+                } elseif ($CertDomain -match '^\*') {
+                    while ($script:OverriddenDomains[$CertDomain] -notlike $CertDomain) {
+                        $script:OverriddenDomains[$CertDomain] = Read-Host "Please provide the FQDN for Nexus matching the '$($CertDomain)' certificate"
+                    }
+                    $script:OverriddenDomains[$CertDomain]
+                }
+            } else {
+                Write-Warning "Could not figure out SSL configuration for $($env:ComputerName) - using 'localhost', specify -HostnameOverride if required."
+                "localhost"
+            }
+            $Config.'application-port-ssl'
+        } elseif ($Config.'application-port' -gt 0) {
+            'http'
+            if ($HostnameOverride) {
+                $HostnameOverride
+            } else {
+                "localhost"
+            }
+            $Config.'application-port'
+        } else {
+            "http"
+            "localhost"
+            "8081"
+        }
+  
+        $Config.'nexus-context-path'
+    }
+  
+    # Set defaults if still not present
+    if (-not $Hostname) { $Hostname = "localhost" }
+    if (-not $Scheme) { $Scheme = 'http' }
+    if (-not $Port) { $Port = '8081' }
+  
+    "$($Scheme)://$($Hostname):$($Port)$($Path)"
+}

--- a/src/public/Realm/Enable-NexusRealm.ps1
+++ b/src/public/Realm/Enable-NexusRealm.ps1
@@ -73,7 +73,7 @@ function Enable-NexusRealm {
         $body = $collection
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -BodyAsArray $Body -Method PUT
+        $null = Invoke-Nexus -UriSlug $urislug -BodyAsArray $Body -Method PUT
 
     }
 }

--- a/src/public/Repository/New-NexusAptHostedRepository.ps1
+++ b/src/public/Repository/New-NexusAptHostedRepository.ps1
@@ -123,7 +123,7 @@ function New-NexusAptHostedRepository {
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
     }
 }

--- a/src/public/Repository/New-NexusAptProxyRepository.ps1
+++ b/src/public/Repository/New-NexusAptProxyRepository.ps1
@@ -312,6 +312,6 @@ function New-NexusAptProxyRepository {
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
     }
 }

--- a/src/public/Repository/New-NexusBowerGroupRepository.ps1
+++ b/src/public/Repository/New-NexusBowerGroupRepository.ps1
@@ -85,7 +85,7 @@ function New-NexusBowerGroupRepository {
         }
         
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
     }
 

--- a/src/public/Repository/New-NexusBowerHostedRepository.ps1
+++ b/src/public/Repository/New-NexusBowerHostedRepository.ps1
@@ -111,7 +111,7 @@ function New-NexusBowerHostedRepository {
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
     }
 }

--- a/src/public/Repository/New-NexusBowerProxyRepository.ps1
+++ b/src/public/Repository/New-NexusBowerProxyRepository.ps1
@@ -304,7 +304,7 @@ function New-NexusBowerProxyRepository {
             }
     
             Write-Verbose $($Body | ConvertTo-Json)
-            Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+            $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
     
         }
     }

--- a/src/public/Repository/New-NexusCocoaPodProxyRepository.ps1
+++ b/src/public/Repository/New-NexusCocoaPodProxyRepository.ps1
@@ -292,7 +292,7 @@ function New-NexusCocoaPodProxyRepository {
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
     }
 

--- a/src/public/Repository/New-NexusConanProxyRepository.ps1
+++ b/src/public/Repository/New-NexusConanProxyRepository.ps1
@@ -292,7 +292,7 @@ process {
     }
 
     Write-Verbose $($Body | ConvertTo-Json)
-    Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+    $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
 }
 

--- a/src/public/Repository/New-NexusCondaProxyRepository.ps1
+++ b/src/public/Repository/New-NexusCondaProxyRepository.ps1
@@ -292,7 +292,7 @@ process {
     }
 
     Write-Verbose $($Body | ConvertTo-Json)
-    Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+    $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
 }
 

--- a/src/public/Repository/New-NexusDockerGroupRepository.ps1
+++ b/src/public/Repository/New-NexusDockerGroupRepository.ps1
@@ -110,7 +110,7 @@ function New-NexusDockerGroupRepository {
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
         if($ForceBasicAuth -eq $false){
             Write-Warning "Docker Bearer Token Realm required since -ForceBasicAuth was not passed."

--- a/src/public/Repository/New-NexusDockerHostedRepository.ps1
+++ b/src/public/Repository/New-NexusDockerHostedRepository.ps1
@@ -151,7 +151,7 @@ function New-NexusDockerHostedRepository {
 
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
         if($ForceBasicAuth -eq $false){
             Write-Warning "Docker Bearer Token Realm required since -ForceBasicAuth was not passed."

--- a/src/public/Repository/New-NexusDockerProxyRepository.ps1
+++ b/src/public/Repository/New-NexusDockerProxyRepository.ps1
@@ -337,7 +337,7 @@ function New-NexusDockerProxyRepository {
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
         if ($ForceBasicAuth -eq $false) {
             Write-Warning "Docker Bearer Token Realm required since -ForceBasicAuth was not passed."

--- a/src/public/Repository/New-NexusGitLfsHostedRepository.ps1
+++ b/src/public/Repository/New-NexusGitLfsHostedRepository.ps1
@@ -108,6 +108,6 @@ function New-NexusGitlfsHostedRepository {
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
     }
 }

--- a/src/public/Repository/New-NexusGoGroupRepository.ps1
+++ b/src/public/Repository/New-NexusGoGroupRepository.ps1
@@ -75,7 +75,7 @@ function New-NexusGoGroupRepository {
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
     }
 
 }

--- a/src/public/Repository/New-NexusGoProxyRepository.ps1
+++ b/src/public/Repository/New-NexusGoProxyRepository.ps1
@@ -293,7 +293,7 @@ New-NexusGoProxyRepository @ProxyParameters
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
     }
 

--- a/src/public/Repository/New-NexusNugetHostedRepository.ps1
+++ b/src/public/Repository/New-NexusNugetHostedRepository.ps1
@@ -117,7 +117,7 @@ function New-NexusNugetHostedRepository {
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $FullUrlSlug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $FullUrlSlug -Body $Body -Method POST
 
     }
 }

--- a/src/public/Repository/New-NexusNugetProxyRepository.ps1
+++ b/src/public/Repository/New-NexusNugetProxyRepository.ps1
@@ -321,7 +321,7 @@ New-NexusNugetProxyRepository @ProxyParameters
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $FullUrlSlug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $FullUrlSlug -Body $Body -Method POST
 
     }
 }

--- a/src/public/Repository/New-NexusRawGroupRepository.ps1
+++ b/src/public/Repository/New-NexusRawGroupRepository.ps1
@@ -93,7 +93,7 @@ function New-NexusRawGroupRepository {
         }
         
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
     }
 

--- a/src/public/Repository/New-NexusRawHostedRepository.ps1
+++ b/src/public/Repository/New-NexusRawHostedRepository.ps1
@@ -116,7 +116,7 @@ function New-NexusRawHostedRepository {
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
 
 
     }

--- a/src/public/Repository/New-NexusRawProxyRepository.ps1
+++ b/src/public/Repository/New-NexusRawProxyRepository.ps1
@@ -305,6 +305,6 @@ New-NexusRawProxyRepository @ProxyParameters
         }
 
         Write-Verbose $($Body | ConvertTo-Json)
-        Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
+        $null = Invoke-Nexus -UriSlug $urislug -Body $Body -Method POST
     }
 }

--- a/src/public/Repository/New-NexusRepository.ps1
+++ b/src/public/Repository/New-NexusRepository.ps1
@@ -186,7 +186,7 @@ function New-NexusRepository {
                 }
 
                 Write-Verbose $($Body | ConvertTo-Json)
-                Invoke-Nexus -UriSlug $FullUrlSlug -Body $Body -Method POST
+                $null = Invoke-Nexus -UriSlug $FullUrlSlug -Body $Body -Method POST
 
             }
             'Proxy' {
@@ -235,7 +235,7 @@ function New-NexusRepository {
                 }
 
                 Write-Verbose $($Body | ConvertTo-Json)
-                Invoke-Nexus -UriSlug $FullUrlSlug -Body $Body -Method POST
+                $null = Invoke-Nexus -UriSlug $FullUrlSlug -Body $Body -Method POST
 
             }
         }


### PR DESCRIPTION
Additionally enhances:
- Improves error handling in Invoke-Nexus
- Passes the build version through to the Chocolatey package
- Adds Remove-NexusRepositoryFolder
- Captures blank-line output from a bunch of functions
- Upgrades the upload-artifact action to v4, as v2 is deprecated

Bugfixes:
- Fixes the SYSTEM user failing to install the package
- Fixes Get-NexusAsset only returning up to 20 results
- Fixes the GitVersion task failing the Action

I'm happy to drop the `Captures blank-line output from a bunch of functions` commit if you'd prefer (though I find the lack of useless output tidier) - when I was analysing things that were different between NexuShell and the functions we had in QSG, I found the following stuff:

- [ ] Invoke-NexusScript -> Set-NexusScript, Start-NexusScript, Remove-NexusScript. No replacement. But actually, unused.
- [x] Invoke-Nexus -> QSG has $AdditionalHeaders. This seems to be needed for Remove-NexusRepositoryFolder. 
- [x] Get-NexusUserToken -> QSG may not actually work due to the auth header used? 
- [x] Remove-NexusRepository -> Parameter completer has minor differences. 
- [x] Remove-NexusRepositoryFolder -> needs to be brought across. 
- [x] New-NexusNugetHostedRepository -> catches the final output in a $null = 
- [x] New-NexusRawHostedRepository -> catches the final output in a $null = 
- [x] Enable-NexusRealm -> catches the final output in a $null =, minor change to spacing in arg completer
- [x] Get-NexusNuGetApiKey -> May not work properly in QSG (or rather, won't work for any account other than admin) and doesn't support context path
- [x] New-NexusRawComponent -> uses Upload-File in NexuShell, so far fewer args. Quite different.
- [x] Get-NexusRepository -> No changes
- [x] Get-NexusRealm -> no changes
- [x] Get-NexusUser -> no change.
- [x] Get-NexusRole -> no change.
- [x] New-NexusUser -> no change.
- [x] New-NexusRole -> no change.
- [x] Set-NexusAnonymousAuth -> no change.

I brought the changes across where appropriate, though only the $null catching stuff needed changes (beyond the addition of various functions.

I have not migrated the `Invoke-NexusScript` function, as it's not currently being used in QSG and simply combined the functinality of a few other functions that _are_ already present.